### PR TITLE
Read in pseudo-bulk expression files

### DIFF
--- a/02-clean-pseudobulk-expression.R
+++ b/02-clean-pseudobulk-expression.R
@@ -18,8 +18,7 @@ expression_files <-
   list.files(file.path(data_dir, "GSE119926"), "GSM", full.names = TRUE)
 
 # read in individual expression files
-expression_df_list <-
-  purrr::map(expression_files[-c(4:5, 25, 28, 33)],
-             function(x)
-               readr::read_tsv(x, skip = 1, col_names = FALSE) %>%
-               tibble::column_to_rownames(var = "X1"))
+expression_df_list <- purrr::map(expression_files,
+                                 function(x)
+                                   readr::read_tsv(x, skip = 1, col_names = FALSE) %>%
+                                   tibble::column_to_rownames(var = "X1"))


### PR DESCRIPTION
Begins to address #16 

This PR adds a script that reads in the pseudo-bulk sample expression files that do not contain parsing issues (see issue #19) and saves each data frame to a list called `expression_df_list`.

**Edit:**
Before saving to the list, each dataframe undergoes some wrangling where the last column is split in half, the gene label added to account for the gene names and the remaining column headers shifted to the right to account for the extra expression value that was in the last column.

This is meant to be the preceding step before we handle isolating the TPM values to average across cells for each sample.

Please let me know if you feel that anything else should be added to this PR (or refactored)! Also let me know what you think of the name of this added R script -- I imagine us building on this script in future PRs but am not sure this is the particular script that would actually generate the pseudo-bulk matrix.