### PR TITLE
Isolate TPM and average values across cells for each sample data frame

### DIFF
--- a/02-clean-pseudobulk-expression.R
+++ b/02-clean-pseudobulk-expression.R
@@ -14,10 +14,11 @@ pseudobulk_metadata <- readr::read_tsv(file.path(processed_data_dir,
                                                  "pseudobulk_metadata.tsv"))
 
 # grab the names of the individual expression files
-expression_files <-
-  list.files(file.path(data_dir, "GSE119926"), "GSM", full.names = TRUE)
-names(expression_files) <-
-  pseudobulk_metadata$title[stringr::str_detect(expression_files, pseudobulk_metadata$title)]
+expression_files <- file.path(data_dir, 
+                              "GSE119926", 
+                              str_c(pseudobulk_metadata$sample_accession, 
+                                    "_", pseudobulk_metadata$title, ".txt.gz"))
+names(expression_files) <- pseudobulk_metadata$title
 
 # read in individual expression files
 expression_df_list <- purrr::map(expression_files,
@@ -31,4 +32,4 @@ expression_df_list <- purrr::map(expression_files,
 tpm_df_list <- lapply(expression_df_list, function(x) 10*(2^x - 1))
 
 # average the TPM values across cells for each data frame
-average_tpm_list <- lapply(expression_df_list, rowMeans)
+average_tpm_list <- lapply(tpm_df_list, rowMeans)


### PR DESCRIPTION
Closes #21 

This PR works to address issue #21 by using the equation noted on https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM3905406 -- `log2(TPM/10+1)` -- to work back and isolate the original TPM values for in each cell.
This PR then uses `rowMeans()` to calculate the average values across genes, having average value for each gene in each sample data frame.

However, this is still in WIP as my calculations when back-checking the equation included in this PR did not equal to the original values in the data frames. Please let me know if you have any thoughts or ideas here!