### PR TITLE
Envest/docker sce genomic features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     version = 3.16)"
 
 # R packages (R-forge)
-RUN install2.r --error --deps TRUE --repos http://r-forge.r-project.org \
+RUN install2.r --error --deps TRUE --repos https://r-forge.r-project.org \
     estimate
     
 # R packages (CRAN)
-RUN install2.r --error --deps TRUE --repos http://cran.r-project.org \
+RUN install2.r --error --deps TRUE --repos https://cran.r-project.org \
     caret \
     doParallel \
     glmnet \


### PR DESCRIPTION
This docker PR adds Bioconductor package `GenomicFeatures`. It also uses `https://` instead of `http://` when specifying the repository for R-forge and CRAN package installations. 

`GenomicFeatures` will enable us to find gene lengths for converting St. Jude RNA-seq read counts into TPM values.

The `https://` change was motivated (necessitated?) by the `Boruta` R package (a dependency of `multiclassPairs`) not downloading properly when `http://` was used.

Thank you!