### PR TITLE
Add bioconductor packages bluster, scater, and scran

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,13 @@ RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     'AnnotationHub', \
     'Biobase', \
     'BiocStyle', \
+    'bluster', \
     'GSVA', \
     'GenomicFeatures', \
     'GEOquery', \
     'leukemiasEset', \
+    'scater', \
+    'scran', \
     'switchBox'), \
     update = FALSE, \
     version = 3.16)"


### PR DESCRIPTION
Adds bioconductor packages bluster, scater, and scran to the Docker image. This was successfully built at `envest/mbssp:R-4.2.2`. Thanks!