### PR TITLE
Envest/42 single cell efficiency

### DIFF
--- a/02-gather_data.R
+++ b/02-gather_data.R
@@ -247,7 +247,7 @@ for (i in 1:length(sample_accession_ids)) {
                                   stringr::str_c(sample_title, "_sce.rds"))
   
   # convert TPM matrix to SingleCellExperiment objects
-  convert_dataframe_list_to_sce(list(tpm_genex_df))[[1]] %>%
+  SingleCellExperiment::SingleCellExperiment(assays = list(counts = tpm_genex_df)) %>%
     # calculate UMAP results
     add_sce_umap() %>%
     # perform clustering


### PR DESCRIPTION
Closes #42 

Through testing I diagnosed that I was running into memory issues working inside docker at multiple stages when working with pseudobulk and SCE objects. Although a very nice list and purrr approach was already implemented (👏 @cbethell ), I found that by using a for loop to work one sample at a time reduced the memory footprint enough to enable working in a smaller docker space. (If I recall, the first implementation of all this may have used a for loop!) The end results are similar, but there may be a slight extension of run time (untested -- not noticeable in practice). This solution relies on lots of functional work done by @cbethell in `utils/single-cell.R` and the overall flow of what we previously implemented. Thanks!