### PR TITLE
Add Okabe-Ito color scheme

### DIFF
--- a/utils/color_schemes.R
+++ b/utils/color_schemes.R
@@ -1,0 +1,6 @@
+# Okabe-Ito is a color-blind friendly color scheme
+# Reference: Okabe, M., & Ito, K. (2008). Color universal design (CUD): How to make figures and presentations that are friendly to colorblind people. https://jfly.uni-koeln.de/color/#pallet (Original work published 2002)
+
+# palette.colors returns a named list, which must be unnamed to not match color names to category labels
+okabe_ito_colors <- unname(grDevices::palette.colors(palette = "Okabe-Ito"))
+


### PR DESCRIPTION
Closes #44 

This PR
- Adds Okabe-Ito color scheme so plotting functions can use this palette

For example, when plotting something, we can `source("utils/color_schemes.R")` and then manually set the fill or colors like `ggplot2::scale_fill_manual(values = okabe_ito_colors)`.

One option mentioned in the issue was to use [a function from the see package](https://easystats.github.io/see/reference/scale_color_okabeito.html) that works like `scale_fill_viridis_d()` and others. However, I had some issues building the docker image to include all of `see`'s dependencies, and the `see` package contains a lot more than just the color palette was want. Hence: just a simple palette.

Thanks!