### PR TITLE
Minimize docker disruption

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,3 @@
-source("renv/activate.R")
+if (! Sys.getenv("RENV_DISABLED")==TRUE ) {
+  source("renv/activate.R")
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,8 @@
 data
 processed_data
 
+# ignore renv for docker
+renv
+
 # Other files to ignore
 .Rproj.user

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,3 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
     version = 3.16)"
 
 ENV RENV_DISABLED=TRUE
-WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,3 +61,4 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
     version = 3.16)"
 
 ENV RENV_DISABLED=TRUE
+WORKDIR /home/rstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
 # R packages (R-forge)
 RUN install2.r --error --deps TRUE --repos https://r-forge.r-project.org \
     estimate
-    
+
 # R packages (CRAN)
-RUN install2.r --error --deps TRUE --repos https://cran.r-project.org \
+RUN install2.r --error --deps TRUE \
     caret \
     doParallel \
     glmnet \
@@ -60,3 +60,5 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
     update = FALSE, \
     version = 3.16)"
 
+ENV RENV_DISABLED=TRUE
+WORKDIR /home


### PR DESCRIPTION
This is a hopefully quick little PR to minimize the disruption that came with adding `renv` to the project. At its core,  it sets an environment variable in the Docker image and modifies .Rprofile to skip activating `renv` if that variable is set. renv can always be activated manually with `renv::activate()` if desired (though then you have to wait for everything to install!)

I also removed the `CRAN` repo from the install2.r call, because that will cause it to potentially use non-fixed versions of packages. Leaving it alone also allows binary installations from PPM (RSPM), so it speeds the build. Let me know if that is what you wanted!

One other note on launching: You had mentioned you use 2 steps to launch, but you should be able to do it all in one with a command like:

```
docker run -it --mount "type=bind,src=$(pwd),dst=/home/rstudio/mb" mb-classifier:latest bash
```

 (where the Docker image is named `mb-classifier`) 
I use `$(pwd)` to mount the current directory (with the name `mb` here) in the working directory (set as `/home/rstudio` in the Dockerfile) for convenience. If you aren't planning to use RStudio itself, you don't need to set the ports and password...