### PR TITLE
Allow automatic renv activation

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,3 +1,3 @@
-if (! Sys.getenv("RENV_DISABLED")==TRUE ) {
+if (Sys.getenv("RENV_DISABLED") != 'TRUE' ) {
   source("renv/activate.R")
 }

--- a/medulloblastoma-classifier.Rproj
+++ b/medulloblastoma-classifier.Rproj
@@ -14,4 +14,3 @@ LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
-DisableExecuteRprofile: Yes


### PR DESCRIPTION
When I went to test the renv environment, I realized that renv was not activating as I expected. At first I thought it was the `.rprofile` which did have an error (of my own doing), but also the Rproj was disabling it, which doesn't seem necessary?