### PR TITLE
Make docker repo lowercase and add platform note for Apple Silicon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It also checks on pull requests that alter relevant files that the image can be 
 To pull the most recent copy of the Docker image, use the following command:
 
 ```sh
-docker pull ghcr.io/AlexsLemonade/medulloblastoma-classifier:latest
+docker pull ghcr.io/alexslemonade/medulloblastoma-classifier:latest
 ```
 
 To run the container, use the following command from the root of this repository:
@@ -27,12 +27,14 @@ docker run \
   --mount type=bind,target=/home/rstudio/medulloblastoma-classifier,source=$PWD \
   -e PASSWORD={PASSWORD} \
   -p 8787:8787 \
-  ghcr.io/AlexsLemonade/medulloblastoma-classifier:latest
+  ghcr.io/alexslemonade/medulloblastoma-classifier:latest
 ```
 
 Be sure to replace `{PASSWORD}`, including the curly braces, with a password of your choice.
 
 You can then access the RStudio at <http://localhost:8787> using the username `rstudio` and the password you just set.
+
+For Apple Silicon users, include the `--platform linux/amd64` tag in the `docker pull` and `docker run` commands.
 
 #### Managing R packages with renv
 


### PR DESCRIPTION
Closes #71 

`README.md` includes directions for using this project's docker container.
The reference to the docker container must be lowercase.

Also, Apple Silicon users need to be reminded to add `--platform linux/amd64` to their `docker pull` and `docker run` commands. Always leave a note!