### PR TITLE
Include `plots/data` in list of directories to sync to/from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ We use an S3 bucket (`s3://data-lab-mb-ssp`) with versioning enabled to manage t
 - `data`
 - `models`
 - `processed_data`
+- `plots/data`
 
 Which are all present in the `.gitignore` file.
 


### PR DESCRIPTION
Does what it says on the tin! I have uploaded my local copies of the TSVs in `plots/data` to S3. The `medulloPackage` prediction on the single-cell data is much slower than the other two models, so it will be great to be able to work on analyzing the results on multiple computers without needing to rerun things.