### PR TITLE
Remove RENV_DISABLED

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,3 +1,1 @@
-if (Sys.getenv("RENV_DISABLED") != 'TRUE' ) {
-  source("renv/activate.R")
-}
+source("renv/activate.R")

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,18 +25,20 @@ RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
 RUN conda install --channel=conda-forge --name=base conda-lock \
   && conda clean --all --yes
 
-# Install renv
-RUN Rscript -e "install.packages('renv')"
-
-# Disable the renv cache to install packages directly into the R library
-ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-
 # Copy conda lock file to image
 COPY conda-lock.yml conda-lock.yml
 
 # restore from conda-lock.yml file and clean up to reduce image size
 RUN conda-lock install -n ${ENV_NAME} conda-lock.yml \
   && conda clean --all --yes
+
+# Activate conda environment on bash launch
+RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
+
+# Use renv for R packages
+WORKDIR /usr/local/renv
+ENV RENV_CONFIG_CACHE_ENABLED=FALSE
+RUN Rscript -e "install.packages('renv')"
 
 # Threading issue with preprocessCore::normalize.quantiles
 # https://support.bioconductor.org/p/122925/#124701
@@ -57,8 +59,5 @@ RUN Rscript -e 'renv::restore()' \
   && rm -rf ~/.cache/R/renv \
   && rm -rf /tmp/downloaded_packages \
   && rm -rf /tmp/Rtmp*
-
-# Activate conda environment on bash launch
-RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
 WORKDIR /home/rstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,4 @@ RUN Rscript -e 'renv::restore()' \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
-ENV RENV_DISABLED=TRUE
 WORKDIR /home/rstudio


### PR DESCRIPTION
We now want to use `renv` within Docker. We also had a problem where the `renv` libraries were not seemingly installed, so I am copying what we do for the training Docker image: https://github.com/AlexsLemonade/training-modules/blob/a53758ed104e787040767e1a58dba92e61c99fe7/Dockerfile#L73C1-L77C1