### PR TITLE
WIP: Jaclyn taroni/docker renv

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,2 @@
 source("renv/activate.R")
+renv::repair()

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ RUN conda-lock install -n ${ENV_NAME} conda-lock.yml \
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
 # Use renv for R packages
-WORKDIR /usr/local/renv
-ENV RENV_CONFIG_CACHE_ENABLED=FALSE
 RUN Rscript -e "install.packages('renv')"
 
 # Threading issue with preprocessCore::normalize.quantiles
@@ -51,10 +49,13 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
     update = FALSE, \
     version = 3.16)"
 
-# Copy the renv.lock file from the host environment to the image
+# Copy over renv lockfile
+WORKDIR /usr/local/renv
 COPY renv.lock renv.lock
 
-# restore from renv.lock file and clean up to reduce image size
+ENV RENV_CONFIG_CACHE_ENABLED=FALSE
+
+# Restore from renv.lock file and clean up to reduce image size
 RUN Rscript -e 'renv::restore()' \
   && rm -rf ~/.cache/R/renv \
   && rm -rf /tmp/downloaded_packages \

--- a/renv.lock
+++ b/renv.lock
@@ -3035,36 +3035,8 @@
     },
     "recipes": {
       "Package": "recipes",
-      "Version": "1.0.6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "Matrix",
-        "R",
-        "cli",
-        "clock",
-        "dplyr",
-        "ellipsis",
-        "generics",
-        "glue",
-        "gower",
-        "hardhat",
-        "ipred",
-        "lifecycle",
-        "lubridate",
-        "magrittr",
-        "purrr",
-        "rlang",
-        "stats",
-        "tibble",
-        "tidyr",
-        "tidyselect",
-        "timeDate",
-        "utils",
-        "vctrs",
-        "withr"
-      ],
-      "Hash": "eb53ffc9674dc9a52c3a7e22d96d3f56"
+      "Version": "1.0.5",
+      "Source": "Repository"
     },
     "rematch": {
       "Package": "rematch",


### PR DESCRIPTION
I've downgraded `recipes` to v1.0.5 but I keep receiving the following warning:

```
The following package(s) have broken symlinks into the cache:

        recipes

Use `renv::repair()` to try and reinstall these packages.
```

This can be resolved by putting `renv::repair()` into `.Rprofile`, as I have done here, but I'm not sure that's the right way to go about things.