### PR TITLE
Use counts for 10X data and clean up paths

### DIFF
--- a/01-gather_metadata.R
+++ b/01-gather_metadata.R
@@ -5,10 +5,10 @@
 
 data_dir <- here::here("data")
 processed_data_dir <- here::here("processed_data")
-processed_pseudobulk_data_dir <- here::here(processed_data_dir, "pseudobulk")
+processed_single_cell_data_dir <- here::here(processed_data_dir, "single_cell")
 
 dir.create(processed_data_dir, showWarnings = FALSE)
-dir.create(processed_pseudobulk_data_dir, showWarnings = FALSE)
+dir.create(processed_single_cell_data_dir, showWarnings = FALSE)
 
 # input file names
 GSE124814_metadata_input_filename <- here::here(data_dir, "GSE124814", "GSE124814_sample_descriptions.xlsx")
@@ -21,7 +21,7 @@ GSE155446_metadata_input_filename <- here::here(data_dir, "GSE155446", "GSE15544
 # output file names
 bulk_metadata_output_filename <- here::here(processed_data_dir,
                                             "bulk_metadata.tsv")
-pseudobulk_metadata_output_filename <- here::here(processed_pseudobulk_data_dir,
+pseudobulk_metadata_output_filename <- here::here(processed_single_cell_data_dir,
                                                   "pseudobulk_metadata.tsv")
 
 ################################################################################

--- a/02-gather_data.R
+++ b/02-gather_data.R
@@ -7,19 +7,19 @@
 
 data_dir <- here::here("data")
 processed_data_dir <- here::here("processed_data")
-pseudobulk_data_dir <- here::here(processed_data_dir, "pseudobulk")
-GSE119926_pseudobulk_dir <- here::here(pseudobulk_data_dir, "GSE119926")
-GSE119926_pseudobulk_sce_dir <- here::here(GSE119926_pseudobulk_dir, "pseudobulk_sce")
-GSE155446_pseudobulk_dir <- here::here(pseudobulk_data_dir, "GSE155446")
-GSE155446_pseudobulk_sce_dir <- here::here(GSE155446_pseudobulk_dir, "pseudobulk_sce")
+single_cell_data_dir <- here::here(processed_data_dir, "single_cell")
+GSE119926_dir <- here::here(single_cell_data_dir, "GSE119926")
+GSE119926_sce_dir <- here::here(GSE119926_dir, "sce")
+GSE155446_dir <- here::here(single_cell_data_dir, "GSE155446")
+GSE155446_sce_dir <- here::here(GSE155446_dir, "sce")
 utils_dir <- here::here("utils")
 
 source(here::here(utils_dir, "convert_gene_names.R"))
 source(here::here(utils_dir, "single-cell.R"))
 source(here::here(utils_dir, "TPM_conversion.R"))
 
-purrr::map(c(GSE119926_pseudobulk_sce_dir,
-             GSE155446_pseudobulk_sce_dir),
+purrr::map(c(GSE119926_sce_dir,
+             GSE155446_sce_dir),
            function(dir) dir.create(dir,
                                     showWarnings = FALSE,
                                     recursive = TRUE))
@@ -31,7 +31,7 @@ purrr::map(c(GSE119926_pseudobulk_sce_dir,
 # metadata inputs
 bulk_metadata_input_filepath <- here::here(processed_data_dir,
                                            "bulk_metadata.tsv")
-pseudobulk_metadata_input_filepath <- here::here(pseudobulk_data_dir,
+pseudobulk_metadata_input_filepath <- here::here(single_cell_data_dir,
                                                  "pseudobulk_metadata.tsv")
 
 # bulk genex inputs
@@ -57,9 +57,9 @@ GENCODE_gene_lengths_filepath <- here::here(data_dir, "GENCODE",
 # genex outputs
 bulk_genex_df_output_filepath <- here::here(processed_data_dir,
                                             "bulk_genex.tsv")
-GSE119926_pseudobulk_genex_df_output_filepath <- here::here(GSE119926_pseudobulk_dir,
+GSE119926_pseudobulk_genex_df_output_filepath <- here::here(GSE119926_dir,
                                                             "GSE119926_pseudobulk_genex.tsv")
-GSE155446_pseudobulk_genex_df_output_filepath <- here::here(GSE155446_pseudobulk_dir,
+GSE155446_pseudobulk_genex_df_output_filepath <- here::here(GSE155446_dir,
                                                             "GSE155446_pseudobulk_genex.tsv")
 
 ################################################################################
@@ -258,7 +258,7 @@ for (sample_iter in seq_along(GSE119926_sample_accession_ids)) {
   }
 
   # define output file names for SCE objects
-  sce_output_filepath = here::here(GSE119926_pseudobulk_sce_dir,
+  sce_output_filepath = here::here(GSE119926_sce_dir,
                                    stringr::str_c(sample_title, "_sce.rds"))
 
   # convert TPM matrix to SingleCellExperiment objects
@@ -331,7 +331,7 @@ for (sample_iter in seq_along(GSE155446_sample_accession_ids)) {
   }
 
   # define output file names for SCE objects
-  sce_output_filepath = here::here(GSE155446_pseudobulk_sce_dir,
+  sce_output_filepath = here::here(GSE155446_sce_dir,
                                    stringr::str_c(sample_title, "_sce.rds"))
 
   # convert counts matrix to SingleCellExperiment objects

--- a/analysis_notebooks/individual_cells_analysis.Rmd
+++ b/analysis_notebooks/individual_cells_analysis.Rmd
@@ -51,19 +51,19 @@ library(SingleCellExperiment)
 ```{r}
 results_dir <- here::here("results")
 processed_data_dir <- here::here("processed_data")
-pseudobulk_data_dir <- here::here(processed_data_dir, "pseudobulk")
-smartseq_data_dir <- here::here(pseudobulk_data_dir, "GSE119926")
-tenx_data_dir <- here::here(pseudobulk_data_dir, "GSE155446")
+single_cell_data_dir <- here::here(processed_data_dir, "single_cell")
+smartseq_data_dir <- here::here(single_cell_data_dir, "GSE119926")
+tenx_data_dir <- here::here(single_cell_data_dir, "GSE155446")
 plots_dir <- here::here("plots")
 plots_data_dir <- here::here(plots_dir, "data")
 models_dir <- here::here("models")
 
 # Get file paths of individual SingleCellExperiment RDS objects
 sce_files <- c(fs::dir_ls(path = fs::path(smartseq_data_dir,
-                                          "pseudobulk_sce"),
+                                          "sce"),
                           glob = "*_sce.rds"),
                fs::dir_ls(path = fs::path(tenx_data_dir,
-                                          "pseudobulk_sce"),
+                                          "sce"),
                           glob = "*_sce.rds")
 )
 # Extract sample titles from the file names

--- a/analysis_notebooks/pseudobulk_analysis.Rmd
+++ b/analysis_notebooks/pseudobulk_analysis.Rmd
@@ -38,7 +38,7 @@ library(patchwork)
 
 ```{r}
 # Directories
-processed_data_dir <- here::here("processed_data", "pseudobulk")
+processed_data_dir <- here::here("processed_data", "single_cell")
 plots_dir <- here::here("plots")
 plots_data_dir <- here::here(plots_dir, "data")
 

--- a/predict/predict_pseudobulk_and_single_cells.R
+++ b/predict/predict_pseudobulk_and_single_cells.R
@@ -18,13 +18,13 @@ models_dir <- here::here("models")
 plots_dir <- here::here("plots")
 plots_data_dir <- here::here(plots_dir, "data")
 processed_data_dir <- here::here("processed_data")
-pseudobulk_data_dir <- here::here(processed_data_dir, "pseudobulk")
-smartseq_data_dir <- here::here(pseudobulk_data_dir, "GSE119926")
-tenx_data_dir <- here::here(pseudobulk_data_dir, "GSE155446")
+single_cell_data_dir <- here::here(processed_data_dir, "single_cell")
+smartseq_data_dir <- here::here(single_cell_data_dir, "GSE119926")
+tenx_data_dir <- here::here(single_cell_data_dir, "GSE155446")
 
 # Input files
 # pseudobulk data for each sample was generated in 02-gather_data.R
-singlecell_metadata_filepath <- here::here(pseudobulk_data_dir,
+singlecell_metadata_filepath <- here::here(single_cell_data_dir,
                                            "pseudobulk_metadata.tsv")
 smartseq_genex_filepath <- here::here(smartseq_data_dir,
                                       "GSE119926_pseudobulk_genex.tsv")
@@ -42,10 +42,10 @@ pseudobulk_plot_data_filepath <- here::here(plots_data_dir, "pseudobulk_test_pre
 
 # Get file paths of individual SingleCellExperiment RDS objects
 sce_files <- c(fs::dir_ls(path = fs::path(smartseq_data_dir,
-                                          "pseudobulk_sce"),
+                                          "sce"),
                           glob = "*_sce.rds"),
                fs::dir_ls(path = fs::path(tenx_data_dir,
-                                          "pseudobulk_sce"),
+                                          "sce"),
                           glob = "*_sce.rds")
 )
 # Extract sample titles from the file names


### PR DESCRIPTION
Closes #108 

We no longer convert individual cell counts to TPM for GSE155446 and use summed counts for the pseudobulk data in `02-gather_data.R`.

While I was here (and ahead of #107), I cleaned up the directory names a bit because we were using a `pseudobulk` directory to house all single-cell data (now: `single_cell`) and `pseudobulk_sce` to hold SingleCellExperiment objects (now: `sce`). This also required changes to:

- `01-gather_metadata.R`
- `analysis_notebooks/individual_cells_analysis.Rmd`
- `analysis_notebooks/pseudobulk_analysis.Rmd`
- `predict/predict_pseudobulk_and_single_cells.R`

The new `single_cell` directory and its contents are on S3. I will remove the old `pseudobulk` and `pseudobulk_sce` after this is approved.

Please focus most of your attention on making sure the counts implementation in `02-gather_data.R` is correct/as described. We will catch any remaining path problems with #107.