### PR TITLE
Add `prop_observed` and `ktsp_mode` experiment to single-cell experiments shell script

### DIFF
--- a/05-single_cell_experiments.sh
+++ b/05-single_cell_experiments.sh
@@ -13,9 +13,35 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Set up directories
 predict_dir="predict"
 analysis_notebooks_dir="analysis_notebooks"
+results_dir="results/single_cells_filtered"
+mkdir -p $results_dir
 
 # Run prediction on single-cell and pseudobulk data
 Rscript "${predict_dir}/predict_pseudobulk.R"
 
 # Render notebook for pseudobulk analysis
 Rscript -e "rmarkdown::render('${analysis_notebooks_dir}/pseudobulk_analysis.Rmd')"
+
+# Vary the proportion of genes in a model that need to be observed to classify
+# an individual cell
+for prop_observed in 0 0.05 0.10 0.15 0.20 0.25 0.5; do
+  
+  # At each proportion observed value, run kTSP using two different modes of
+  # filtering out cells
+  for filtering_type in gene rule; do
+  
+    Rscript "${predict_dir}/predict_single_cells.R" \
+      --output_file "${results_dir}/ktsp_${prop_observed}_${filtering_type}.tsv" \
+      --model_type ktsp \
+      --prop_observed ${prop_observed} \
+      --ktsp_mode ${filtering_type}
+      
+  done
+  
+  # Random forest models using gene filtering per proportion observed value
+  Rscript "${predict_dir}/predict_single_cells.R" \
+    --output_file "${results_dir}/rf_${prop_observed}.tsv" \
+    --model_type rf \
+    --prop_observed ${prop_observed}
+  
+done


### PR DESCRIPTION
Stacked on #123 
Towards #106 

Here I'm altering the shell script to generate results for a variety of `prop_observed` values and the two different `ktsp_mode`. I expect to plot these results in a follow-up notebook!