### PR TITLE
Set RETICULATE_PYTHON in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV RENV_DOCKER=TRUE
 # set environment variables to install conda
 ENV PATH="/opt/conda/bin:${PATH}"
 
+# Set an environment variable to tell reticulate where to find Python
+ENV RETICULATE_PYTHON="/opt/conda/bin/python"
+
 # Install conda via miniforge
 # adapted from https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile
 RUN curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /tmp/miniforge.sh \


### PR DESCRIPTION
I am having trouble running the Docker container on multiple Mac computers. I need to load R in safe mode, and when I do I get shown the following in the console:

```
Error in python_config_impl(python) : 
  Error 1 occurred running /opt/conda/bin/python3: 
Calls: do.call ... <Anonymous> -> <Anonymous> -> python_config -> python_config_impl
In addition: Warning message:
In system2(command = python, args = shQuote(script), stdout = TRUE,  :
  running command ''/opt/conda/bin/python3' '/usr/local/lib/R/site-library/reticulate/config/config.py' 2>/dev/null' had status 1
Execution halted
```

Running `reticulate::conda_list()` ([per SO](https://stackoverflow.com/questions/71774725/how-to-fix-reticulate-error-in-rstudio-to-use-python)) yields:

```
                        name                                                python
1                       base                                 /opt/conda/bin/python
2 medulloblastoma-classifier /opt/conda/envs/medulloblastoma-classifier/bin/python
```

I am wondering whether this can be resolved by setting the `RETICULATE_PYTHON` environment variable in the Dockerfile.

